### PR TITLE
Export Ensemble does not save vendor directory

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -285,6 +285,7 @@
 					$this->__addFolderToArchive($archive, 'symphony', DOCROOT);
 					$this->__addFolderToArchive($archive, 'workspace', DOCROOT);
 					$this->__addFolderToArchive($archive, 'install', DOCROOT);
+					$this->__addFolderToArchive($archive, 'vendor', DOCROOT);
 
 					$archive->addFromString('install/includes/config_default.php', $config_template);
 					$archive->addFromString('install/includes/install.sql', $sql_schema);


### PR DESCRIPTION
Vendor directory was not being saved in export ensemble .zip file. Added the directory in the __createZipArchive function.